### PR TITLE
feat: update getMatchingJobs' searching algo

### DIFF
--- a/functions/test/index.test.js
+++ b/functions/test/index.test.js
@@ -80,24 +80,33 @@ describe("Cloud Functions", () => {
     })
 
     // Add jobs
-    await firestore.collection("jobs").doc("1").set({
-      name: "Sample Job 1",
-      description: "The first sample job",
-      avgSalary: 100000,
-      qualifications: ["1"],
-    })
-    await firestore.collection("jobs").doc("2").set({
-      name: "Sample Job 2",
-      description: "The second sample job",
-      avgSalary: 200000,
-      qualifications: ["2"],
-    })
-    await firestore.collection("jobs").doc("3").set({
-      name: "Sample Job 3",
-      description: "The third sample job",
-      avgSalary: 300000,
-      qualifications: ["3"],
-    })
+    await firestore
+      .collection("jobs")
+      .doc("1")
+      .set({
+        name: "Sample Job 1",
+        description: "The first sample job",
+        avgSalary: 100000,
+        qualifications: ["1"],
+      })
+    await firestore
+      .collection("jobs")
+      .doc("2")
+      .set({
+        name: "Sample Job 2",
+        description: "The second sample job",
+        avgSalary: 200000,
+        qualifications: ["1", "2"],
+      })
+    await firestore
+      .collection("jobs")
+      .doc("3")
+      .set({
+        name: "Sample Job 3",
+        description: "The third sample job",
+        avgSalary: 300000,
+        qualifications: ["1", "2", "3"],
+      })
 
     // Add job listings
     await GeoFirestore.collection("jobs")
@@ -293,18 +302,18 @@ describe("Cloud Functions", () => {
           name: "Sample Job 2",
           description: "The second sample job",
           avgSalary: 200000,
-          qualifications: ["2"],
+          qualifications: ["1", "2"],
         },
         3: {
           name: "Sample Job 3",
           description: "The third sample job",
           avgSalary: 300000,
-          qualifications: ["3"],
+          qualifications: ["1", "2", "3"],
         },
       })
     })
     it("should return any jobs that match the search", async () => {
-      const data = { qualifications: ["1", "3"] }
+      const data = { qualifications: ["1", "2"] }
 
       const wrapped = test.wrap(myFunctions.getMatchingJobs)
       const output = await wrapped(data)
@@ -315,11 +324,11 @@ describe("Cloud Functions", () => {
           avgSalary: 100000,
           qualifications: ["1"],
         },
-        3: {
-          name: "Sample Job 3",
-          description: "The third sample job",
-          avgSalary: 300000,
-          qualifications: ["3"],
+        2: {
+          name: "Sample Job 2",
+          description: "The second sample job",
+          avgSalary: 200000,
+          qualifications: ["1", "2"],
         },
       })
     })


### PR DESCRIPTION
`getMatchingJobs` used to get any job that had any qualifications matching the list of qualifications the user provided.
This is not intuitive, as a job would likely require all the qualifications listed.
Thus, `getMatchingJobs` has been updated to reflect this expected behaviour.

BREAKING CHANGE: getMatchingJobs no longer behaves as it did previously